### PR TITLE
Update entitlements to support BlueArchive

### DIFF
--- a/PlayCover/AppInstaller/Utils/Entitlements.swift
+++ b/PlayCover/AppInstaller/Utils/Entitlements.swift
@@ -239,6 +239,7 @@ class Entitlements {
     ]
     private static let BASE_PROFILE = [
                                                 "(deny process-fork)",
+                                                "(allow file* file-read* file-read-metadata file-ioctl) (literal \"/tmp/cclibraries-ngl-log.cfg\")",
                                                 "(deny file* file-read* file-read-metadata file-ioctl)",
                                                 "(allow file* file-read* file-read-metadata file-ioctl (literal \"/usr/lib/libobjc-trampolines.dylib\"))",
                                                 "(allow file-read-metadata (subpath \"/private/var/db/timezone/\"))",


### PR DESCRIPTION
Thanks for sharing the great project :D

BlueArchive need access to `/tmp/cclibraries-ngl-log.cfg` or it will crash.
No need to disable SIP and the `amfi` trick.

It is known that Nexon is using `xigncode` to detect modifications to the app.
A ban is possible.
So use it at your own risk.

![telegram-cloud-photo-size-5-6136257142466916539-y](https://user-images.githubusercontent.com/371475/173215152-96a44582-f46d-4145-8ae3-4b9bd0d864ec.jpg)

<img width="1051" alt="1" src="https://user-images.githubusercontent.com/371475/173215139-1922bef6-5ae6-4b57-9d1a-d18d730919e8.png">

<img width="1051" alt="2" src="https://user-images.githubusercontent.com/371475/173215203-99345756-d4cd-4c7b-9db8-dbbef0d1d847.png">

<img width="1051" alt="3" src="https://user-images.githubusercontent.com/371475/173215172-57225336-1c5f-4b12-9605-36e402506584.png">

